### PR TITLE
framemanager : avoid flickering under GTK

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -6346,6 +6346,7 @@ class AuiManager(wx.EvtHandler):
             self.DoUpdate()
 
     def DoUpdateEvt(self, evt):
+        self.Unbind(wx.EVT_WINDOW_CREATE)
         wx.CallAfter(self.DoUpdate)
 
     def DoUpdate(self):


### PR DESCRIPTION
Here is a proposition to avoid screen flickering due to multiple refresh under GTK.
This PR complete this one #330 which fix the problem for other port.

